### PR TITLE
Search domain example job

### DIFF
--- a/jobs/search_domain/spec
+++ b/jobs/search_domain/spec
@@ -1,0 +1,12 @@
+---
+name: search_domain
+
+templates:
+  pre-start.sh.erb: bin/pre-start
+
+properties:
+  search_domain:
+    description: Default resolv.conf serach domain
+    example:
+      search_domain: "pivotal.io"
+

--- a/jobs/search_domain/templates/pre-start.sh.erb
+++ b/jobs/search_domain/templates/pre-start.sh.erb
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+echo search <%=p('search_domain')%> >> /etc/resolv.conf
+

--- a/jobs/search_domain/templates/pre-start.sh.erb
+++ b/jobs/search_domain/templates/pre-start.sh.erb
@@ -2,5 +2,5 @@
 
 set -ex
 
-echo search <%=p('search_domain')%> >> /etc/resolv.conf
-
+echo search <%=p('search_domain')%> >> /etc/resolvconf/resolv.conf.d/base
+/sbin/resolvconf -u

--- a/manifests/search_domain.yml
+++ b/manifests/search_domain.yml
@@ -1,0 +1,11 @@
+releases:
+- name: os-conf
+  version: 7+dev1
+
+addons:
+- name: os_configuration
+  jobs:
+  - name: search_domain
+    release: os-conf
+  properties:
+    search_domain: "google.com"

--- a/manifests/search_domain.yml
+++ b/manifests/search_domain.yml
@@ -1,6 +1,6 @@
 releases:
 - name: os-conf
-  version: 7+dev1
+  version: 7+dev3
 
 addons:
 - name: os_configuration


### PR DESCRIPTION
Adds a search domain to BOSH VMs for hostname resolution (useful for legacy enterprise networks without FQDN for some internal app dependencies).  