### PR TITLE
New job, `enable_ipv6`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ BOSH Release that enables configuration of the Operating System
 - change TCP keepalive kernel args (job: `tcp_keepalive`)
 - configure resolv.conf search domain (job: `search_domain`)
 - add UNIX users to VM (job: `user_add`)
+- enable IPv6 (job: `enable_ipv6`)
 
 ## Usage
 
@@ -57,6 +58,19 @@ instance_groups:
     release: os-conf
     properties:
       search_domain: pivotal.io
+```
+
+In this example, we enable the IPv6 protocol (note: there are no properties
+for the `enable_ipv6` job):
+
+```
+instance_groups:
+- name: network-infrastructure
+  jobs:
+  - name: enable_ipv6
+    templates:
+    - release: os-conf
+      name: enable_ipv6
 ```
 
 ##  Examples

--- a/jobs/enable_ipv6/monit
+++ b/jobs/enable_ipv6/monit
@@ -1,0 +1,5 @@
+check process enable_ipv6
+  with pidfile /var/vcap/sys/run/enable_ipv6/pid
+  start program "/var/vcap/jobs/enable_ipv6/bin/ctl start"
+  stop program "/var/vcap/jobs/enable_ipv6/bin/ctl stop"
+  group vcap

--- a/jobs/enable_ipv6/spec
+++ b/jobs/enable_ipv6/spec
@@ -1,0 +1,10 @@
+---
+name: enable_ipv6
+
+templates:
+  ctl.erb: bin/ctl
+  sysctl.conf.erb: etc/sysctl.d/61-bosh-enable_ipv6-release.conf
+
+packages: []
+
+properties: {}

--- a/jobs/enable_ipv6/templates/ctl.erb
+++ b/jobs/enable_ipv6/templates/ctl.erb
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# we enable tracing and log everything; there's nothing to hide here.
+set -eux
+
+JOB_DIR=/var/vcap/jobs/enable_ipv6
+SYSCTL_RELATIVE_PATH=etc/sysctl.d/61-bosh-enable_ipv6-release.conf
+RUN_DIR=/var/vcap/sys/run/enable_ipv6
+LOG_DIR=/var/vcap/sys/log/enable_ipv6
+PIDFILE=${RUN_DIR}/pid
+
+mkdir -p $RUN_DIR $LOG_DIR
+exec -- \
+  >>  $LOG_DIR/enable_ipv6.stdout.log \
+  2>> $LOG_DIR/enable_ipv6.stderr.log
+
+case $1 in
+
+  start)
+    chown -R vcap:vcap $RUN_DIR $LOG_DIR
+    cp -f ${JOB_DIR}/${SYSCTL_RELATIVE_PATH} /${SYSCTL_RELATIVE_PATH}
+
+    # this script is a fire-and-forget, but monit doesn't play that game,
+    # so we tell monit to check a pid that's always there
+    echo 1 > $PIDFILE
+
+    # set the kernel variables, again. All the variables
+    sysctl --system
+
+    ;;
+
+  stop)
+    rm -f $PIDFILE
+
+    ;;
+
+  *)
+    echo "Usage: ctl {start|stop}" ;;
+
+esac

--- a/jobs/enable_ipv6/templates/sysctl.conf.erb
+++ b/jobs/enable_ipv6/templates/sysctl.conf.erb
@@ -1,0 +1,12 @@
+# undo BOSH's stemcell's IPv6 lockdowns
+# 10-ipv6-privacy.conf
+net.ipv6.conf.all.use_tempaddr = 0
+net.ipv6.conf.default.use_tempaddr = 0
+# 60-bosh-sysctl.conf
+net.ipv6.conf.all.accept_ra=1
+net.ipv6.conf.default.accept_ra=1
+net.ipv6.conf.all.disable_ipv6=0
+net.ipv6.conf.default.disable_ipv6=0
+net.ipv6.conf.default.accept_redirects=1
+net.ipv6.conf.all.accept_redirects=1
+net.ipv6.route.flush=0

--- a/manifests/enable_ipv6.yml
+++ b/manifests/enable_ipv6.yml
@@ -1,0 +1,39 @@
+name: enable_ipv6
+
+releases:
+- name: os-conf
+  version: latest
+
+stemcells:
+- alias: ubuntu
+  os: ubuntu-trusty
+  version: latest
+- alias: centos
+  os: centos-7
+  version: latest
+
+instance_groups:
+- name: enable_ipv6-ubuntu
+  instances: 1
+  networks:
+  - name: default
+  vm_type: default
+  stemcell: ubuntu
+  templates:
+  - release: os-conf
+    name: enable_ipv6
+- name: enable_ipv6-centos
+  instances: 1
+  networks:
+  - name: default
+  vm_type: default
+  stemcell: centos
+  templates:
+  - release: os-conf
+    name: enable_ipv6
+
+update:
+  canaries: 1
+  max_in_flight: 10
+  canary_watch_time: 1000-30000
+  update_watch_time: 1000-30000


### PR DESCRIPTION
- final release has *not* been created; lack of creds
- no properties
- undoes `sysctl` settings that disable IPv6
  - Security Technical Implementation Guide (STIG)
    [V-38546](https://www.stigviewer.com/stig/red_hat_enterprise_linux_6/2013-06-03/finding/V-38546)
  - Pivotal Tracker
    [story](https://www.pivotaltracker.com/n/projects/956238/stories/119692507)
  - GitHub
    [commit](https://github.com/cloudfoundry/bosh/commit/44607ae50110ca0c723f7509073d28542a7d7a4d)


We chose to disable the IPv6 privacy settings; we believe that in this
context they are unimportant (to whit, the privacy settings are to
disable the ability to track permanent physical devices as they connect
to various networks). Our instances connect permanently to networks, and
they are volatile (i.e. they are frequently re-deployed).

IPv6 creates "permanent" addresses based on the 48-bit MAC address.
Privacy experts have pointed out that this will allow devices
(e.g. cellphones) who connect to websites (or other services) via
IPv6 to be tracked across multiple networks (e.g. via cell service,
via WiFi, etc...).