### PR TITLE
Add support for enabling kernel modules

### DIFF
--- a/jobs/modprobe/spec
+++ b/jobs/modprobe/spec
@@ -1,0 +1,15 @@
+---
+name: modprobe
+
+templates:
+  pre-start.erb: bin/pre-start
+
+properties:
+  modules:
+    default: []
+    description: List of kernel modules to be loaded (modprobed)
+    example:
+      modules:
+      - aufs
+      - speedstep-lib
+

--- a/jobs/modprobe/templates/pre-start.erb
+++ b/jobs/modprobe/templates/pre-start.erb
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+<% p('modules').each do |m| %>
+  modprobe <%= m %>
+<% end %>


### PR DESCRIPTION
Garden’s filesystem plugin shed requires aufs. The shed plugin modprobes aufs normally when used. 

When garden is run inside a container, the plugin cannot modprobe so we’d like the host VM to already have aufs enabled. This is for use in our CI.