### PR TITLE
Accept an array of certs

### DIFF
--- a/jobs/ca_certs/spec
+++ b/jobs/ca_certs/spec
@@ -16,3 +16,15 @@ properties:
       -----BEGIN CERTIFICATE-----
       MIIClTCCAf4CCQDc6hJtvGB8RjANBgkqhkiG9w0BAQUFADCBjjELMAk...
       -----END CERTIFICATE-----
+  cert_list:
+    description: "Array of concatenated set of certificates in PEM format"
+    default: []
+    example:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIClTCCAf4CCQDc6hJtvGB8RjANBgkqhkiG9w0BAQUFADCBjjELMAk...
+      -----END CERTIFICATE-----
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIClTCCAf4CCQDc6hJtvGB8RjANBgkqhkiG9w0BAQUFADCBjjELMAk...
+      -----END CERTIFICATE-----

--- a/jobs/ca_certs/templates/certs.erb
+++ b/jobs/ca_certs/templates/certs.erb
@@ -1,1 +1,4 @@
 <%= p("certs", "") %>
+<% p("cert_list", []).each do |cert| %>
+<%= cert %>
+<% end %>


### PR DESCRIPTION
This PR adds an additional `cert_list` array property to `ca_certs` job. It allows to stack certificates from multiple obs files as requested in #34.