### PR TITLE
Allow specifying groups for created users

### DIFF
--- a/jobs/user_add/spec
+++ b/jobs/user_add/spec
@@ -21,6 +21,7 @@ properties:
       users:
       - name: user1
         public_key: ssh-rsa AAAA ...
+        groups: [ group1 ]
       - name: user2
         # mkpasswd -m sha-512 <PASSWORD> <SALT>
         crypted_password: $6$saltysalt$eF06vmEKaMhOr8jcnyfJJGuaU/Khq3DpH4M/7T.ziGNjhEEv3o9tgaX5VciMGAbgfE0CH9XrcpHi9kgmVv1Z2.
@@ -28,3 +29,4 @@ properties:
         shell: /bin/rbash
       - name: nosudo
         sudo: false
+        groups: []

--- a/jobs/user_add/templates/pre-start.sh.erb
+++ b/jobs/user_add/templates/pre-start.sh.erb
@@ -11,7 +11,10 @@ set -ex
 
 <% p('users').each do |user_hash| %>
   <%  user = user_hash['name']
-      sudo = user_hash['sudo'].nil? ? true : !!user_hash['sudo']
+      groups = user_hash['groups'].nil? ? ['vcap'] : user_hash['groups']
+      groups |= ["bosh_sshers"]
+      groups |= ["admin", "bosh_sudoers"] if user_hash['sudo']
+
       crypted_password = user_hash['crypted_password']
       public_key = user_hash['public_key']
 
@@ -42,13 +45,8 @@ set -ex
     usermod -s <%=user_hash['shell']%> <%=user%>
   <% end %>
 
-  if grep -q 'bosh_sshers' /etc/group; then
-    <% if sudo %>
-      usermod -G vcap,admin,bosh_sudoers,bosh_sshers <%=user%>
-    <% else %>
-      usermod -G vcap,bosh_sshers <%=user%>
-    <% end %>
-  fi
+  echo <%= groups.join(' ') %> | xargs -n 1 groupadd -f
+  usermod -G <%= groups.join(',') %> <%=user%>
 
   chmod 700 ~<%=user%>
   mkdir -p ~<%=user%>/.ssh


### PR DESCRIPTION
This PR allows specifying the groups which the created user will be added to.
Non-existing groups will be created. By default users will be assigned to the `vcap` group.
Additionally `bosh_sshers` and depending on the `sudo:` property `admin` and `bosh_sudoers` are added aswell.

Our usecase for this feature is wanting to limit access to `/var/vcap/*` for our added user.