### PR TITLE
Add limits job

### DIFF
--- a/jobs/limits/spec
+++ b/jobs/limits/spec
@@ -1,0 +1,18 @@
+---
+name: limits
+
+templates:
+  pre-start.sh.erb: bin/pre-start
+
+properties:
+  nofile.soft:
+    description: |
+      Modifies the soft max number of open files. Linux defaults to 1024.
+    example: 16384
+    default: 16384
+  nofile.hard:
+    description: |
+      Modifies the hard max number of open files. Linux defaults to 4096.
+      It needs to be greater or equal to the soft limit
+    example: 16384
+    default: 16384

--- a/jobs/limits/templates/pre-start.sh.erb
+++ b/jobs/limits/templates/pre-start.sh.erb
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if pidof systemd >/dev/null 2>&1; then
+  NEW_NOFILE="DefaultLimitNOFILE=<%= p("nofile.soft") %>:<%= p("nofile.hard") %>"
+  LINE=$(grep -nE '^DefaultLimitNOFILE=' /etc/systemd/system.conf | tail -1 | awk -F: '{print $1}')
+  if [[ -n "$LINE" ]]; then
+    sed -i "${LINE}s/.*/$NEW_NOFILE/" /etc/systemd/system.conf
+  else
+    echo "$NEW_NOFILE" >> /etc/systemd/system.conf
+  fi
+  systemctl daemon-reload
+else
+  >&2 echo "Failed to update systemd configuration because systemd is not running"
+fi
+
+pid=$(pgrep monit | awk '{print $1}')
+
+if command -v prlimit >/dev/null 2>&1; then
+  while [[ $pid -gt 1 ]]; do
+    prlimit --pid "$pid" --nofile=<%= p("nofile.soft") %>:<%= p("nofile.hard") %>
+    pid=$(ps -o ppid:1= -p "$pid")
+  done
+else
+  >&2 echo "Failed to set limits because command 'prlimit' is not available"
+fi

--- a/src/os-conf-acceptance-tests/assets/manifest.yml
+++ b/src/os-conf-acceptance-tests/assets/manifest.yml
@@ -79,6 +79,12 @@ instance_groups:
       limits_conf: |
         * soft nofile 60000
         * hard nofile 100000
+  - name: limits
+    release: os-conf
+    properties:
+      nofile:
+        soft: 60000
+        hard: 100000
   - name: login_banner
     release: os-conf
     properties:

--- a/src/os-conf-acceptance-tests/limits_test.go
+++ b/src/os-conf-acceptance-tests/limits_test.go
@@ -1,0 +1,50 @@
+package os_conf_acceptance_tests_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Limits", func() {
+	BeforeEach(func() {
+		if boshStemcell == "ubuntu-trusty" {
+			Skip("Trusty Stemcells are not supported.")
+		}
+	})
+
+	Context("when limits are configured", func() {
+		It("sets the limits for the monit process", func() {
+			session := boshSSH("os-conf/0", "pid=$(ps -e | grep monit | awk '{print $1}'); cat /proc/$pid/limits | grep 'Max open files' | awk '{print $4}'")
+			Eventually(session, 30*time.Second).Should(gbytes.Say("60000"))
+			Eventually(session, 30*time.Second).Should(gexec.Exit(0))
+
+			session = boshSSH("os-conf/0", "pid=$(ps -e | grep monit | awk '{print $1}'); cat /proc/$pid/limits | grep 'Max open files' | awk '{print $5}'")
+			Eventually(session, 30*time.Second).Should(gbytes.Say("100000"))
+			Eventually(session, 30*time.Second).Should(gexec.Exit(0))
+		})
+
+		It("sets the limits for the parent process", func() {
+			session := boshSSH("os-conf/0", "pid=$(ps -e | grep monit | awk '{print $1}'); pid_parent=$(ps -o ppid:1= -p $pid); cat /proc/$pid_parent/limits | grep 'Max open files' | awk '{print $4}'")
+			Eventually(session, 30*time.Second).Should(gbytes.Say("60000"))
+			Eventually(session, 30*time.Second).Should(gexec.Exit(0))
+
+			session = boshSSH("os-conf/0", "pid=$(ps -e | grep monit | awk '{print $1}'); pid_parent=$(ps -o ppid:1= -p $pid); cat /proc/$pid_parent/limits | grep 'Max open files' | awk '{print $5}'")
+			Eventually(session, 30*time.Second).Should(gbytes.Say("100000"))
+			Eventually(session, 30*time.Second).Should(gexec.Exit(0))
+		})
+
+		It("sets the limits for the systemd process", func() {
+			session := boshSSH("os-conf/0", "systemctl show | grep 'DefaultLimitNOFILESoft=' | awk -F= '{print $2}'")
+			Eventually(session, 30*time.Second).Should(gbytes.Say("60000"))
+			Eventually(session, 30*time.Second).Should(gexec.Exit(0))
+
+			session = boshSSH("os-conf/0", "systemctl show | grep 'DefaultLimitNOFILE=' | awk -F= '{print $2}'")
+			Eventually(session, 30*time.Second).Should(gbytes.Say("100000"))
+			Eventually(session, 30*time.Second).Should(gexec.Exit(0))
+		})
+	})
+})


### PR DESCRIPTION
* set systemd default open file limit and reloads it
* set the prlimit for monit and its parent processes in pre-start script
* trusty stemcells are not supported

Fixes pivotal-cf/ulimit-release/issues/6

Co-authored-by: David Ansari <david.ansari@sap.com>
Co-authored-by: Sebastian Heid <sebastian.heid@sap.com>