### PR TITLE
Add migration between persistent_homes true/false

### DIFF
--- a/jobs/user_add/templates/pre-start.sh.erb
+++ b/jobs/user_add/templates/pre-start.sh.erb
@@ -27,8 +27,16 @@ set -ex
         raise "User: '#{user}' with crypted_password: '#{crypted_password}' does not appear to be a SHA512 encrypted password."
       end
       %>
-
-  getent passwd <%=user%> > /dev/null || useradd --create-home <%=user%> --base-dir "$home_dir"
+  # when entity exists and has a different home directory, migrate it
+  entity=$(getent passwd <%=user%> || true)
+  if [ -n "$entity" ]; then
+    entity_home=$(echo "$entity" | awk -F':' '{print $(NF-1)}')
+    if [ "$entity_home" != "$home_dir/<%=user%>" ]; then
+      usermod -m -d "$home_dir/<%=user%>" <%=user%> || mkdir -p "$home_dir/<%=user%>"
+    fi
+  else
+    useradd --create-home <%=user%> --base-dir "$home_dir"
+  fi
   chown -R <%=user%>: "$home_dir/<%=user%>"
   passwd -d <%=user%>
 


### PR DESCRIPTION
This PR makes it possible to smoothly transition between persistent_homes true/false without loosing data.

The following premises apply for this:
- if you migrate from false (volatile homes), the "bosh deploy" step does not recreate the VMs
- no user is logged or has files open in during the time of the upgrade (open work will be lost because data is moved accross devices)
- the respective destination folder (new_home_dir/user) is not already present
- the destination disk has enough free disk space