### PR TITLE
[#171751912] lock password if crypted_password is not set

### DIFF
--- a/jobs/user_add/templates/pre-start.sh.erb
+++ b/jobs/user_add/templates/pre-start.sh.erb
@@ -60,5 +60,8 @@ set -ex
     echo '<%=public_key%>' > ~<%=user%>/.ssh/authorized_keys
     chmod 600 ~<%=user%>/.ssh/authorized_keys
     chown -R <%=user%> ~<%=user%>/.ssh
+    <% if crypted_password.nil? %>
+      passwd -l <%=user%>
+    <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
STIG UBTU-16-010160
Scanners are flagging `bbr` user since it has an empty password. 
https://github.com/cloudfoundry/os-conf-release/pull/41 and https://github.com/cloudfoundry/os-conf-release/pull/40 were workarounds but required the `crypted_password` to be set even though password based login wasn't being used.



