### PR TITLE
Adding the option to delete system certificates to the job ca_certs

### DIFF
--- a/jobs/ca_certs/spec
+++ b/jobs/ca_certs/spec
@@ -6,6 +6,9 @@ templates:
   pre-start.sh.erb: bin/pre-start
 
 properties:
+  delete_system_certs: 
+    description: "Flag to delete the default trusted certificate store"
+    default: false
   certs:
     description: "Concatenated set of certificates in PEM format"
     default: ""

--- a/jobs/ca_certs/templates/pre-start.sh.erb
+++ b/jobs/ca_certs/templates/pre-start.sh.erb
@@ -4,6 +4,14 @@
 
 CONF_DIR=/var/vcap/jobs/ca_certs/config
 
+<% if p("delete_system_certs") %>
+# deleting the certificates on ca-certificates.conf
+echo '' > /etc/ca-certificates.conf
+rm -rf /usr/share/ca-certificates/*
+# choose to *not* trust new certs
+echo 'ca-certificates ca-certificates/trust_new_crts select no' | debconf-set-selections -
+<% end %>
+
 echo "deleting old certificates"
 rm -f /usr/local/share/ca-certificates/bosh_os_conf_ca_cert_*
 


### PR DESCRIPTION
For very restrictive environments that should only trust their own certificates we're adding an option to clear all the system certificates.