### PR TITLE
add jammy compability

### DIFF
--- a/jobs/harden_sshd/templates/pre-start.sh.erb
+++ b/jobs/harden_sshd/templates/pre-start.sh.erb
@@ -8,7 +8,7 @@ sshd_version=$(nc localhost 22 -w1)
 <% end %>
 
 <% unless p('allow_stream_local_forwarding') %>
-if echo "${sshd_version}" | grep -q "OpenSSH_7"; then
+if [[ $(echo "${sshd_version}" | sed  's#.*OpenSSH_\([0-9]*\)\..*#\1#g') -gt 6 ]]; then
     sed "/^ *AllowStreamLocalForwarding/d" -i /etc/ssh/sshd_config
     echo 'AllowStreamLocalForwarding no' >> /etc/ssh/sshd_config
 fi

--- a/src/os-conf-acceptance-tests/assets/manifest.yml
+++ b/src/os-conf-acceptance-tests/assets/manifest.yml
@@ -96,7 +96,7 @@ instance_groups:
     release: os-conf
     properties:
       modules:
-      - aufs
+      - lp
   - name: monit
     release: os-conf
     properties:

--- a/src/os-conf-acceptance-tests/modprobe_test.go
+++ b/src/os-conf-acceptance-tests/modprobe_test.go
@@ -12,7 +12,7 @@ import (
 var _ = Describe("Modprobe", func() {
 	It("enables the kernel modules specified", func() {
 		session := boshSSH("os-conf/0", "lsmod")
-		Eventually(session, 30*time.Second).Should(gbytes.Say("aufs"))
+		Eventually(session, 30*time.Second).Should(gbytes.Say("lp"))
 		Eventually(session, 30*time.Second).Should(gexec.Exit(0))
 	})
 })


### PR DESCRIPTION
the harden sshd job wouldn't work on jammy because it uses a newer
openssh version than 7. the initial commit that updated the behaviour to
add trusty support

see: 3d44807717847bb9ddca4de9f7d9348ecee9064e

on jammy that check (which I assume is checking that the minimum version
is OpenSSH_7) fails and the property is not added. Update the check to
parse out the major version and check if is greater than 6 which should
keep trusty compability and work for future two digit major versions of
OpenSSH.

additionally the test deployments tried loading aufs which is shipped
with jammy anymore. so loading it won't work either. switch to `lp` kernel
module because lp is also used in the stemcell builder tests and is not
only available in bionic and jammy but also in fips mode (which for this
usecase doesn't matter).

compare:

https://github.com/cloudfoundry/bosh-linux-stemcell-builder/commit/19b512a91aa65c619e204deb4eb8b2d53b6f118a