### PR TITLE
Update pre-start.sh.erb in harden_ssh for noble stemcell

### DIFF
--- a/jobs/harden_sshd/templates/pre-start.sh.erb
+++ b/jobs/harden_sshd/templates/pre-start.sh.erb
@@ -25,7 +25,7 @@ fi
 <% end %>
 
 if command -v systemctl &> /dev/null; then
-    systemctl restart sshd
+    systemctl restart ssh
 else
     /etc/init.d/ssh restart
 fi


### PR DESCRIPTION
`sshd.service` is a pointer to `ssh.service` in jammy, and this pointer is removed in noble.

bionic would be the only one affected by this change. but his is not supported anymore
so no worries there