### PR TITLE
feat: add iptables job

### DIFF
--- a/jobs/iptables/monit
+++ b/jobs/iptables/monit
@@ -1,0 +1,5 @@
+check file iptables
+  with path /var/vcap/sys/run/iptables/iptables.check
+  start program "/var/vcap/jobs/iptables/bin/ctl start"
+  stop program "/var/vcap/jobs/iptables/bin/ctl stop"
+  group vcap

--- a/jobs/iptables/spec
+++ b/jobs/iptables/spec
@@ -1,0 +1,16 @@
+---
+name: iptables
+
+templates:
+  bin/ctl: bin/ctl
+  bin/enable.sh: bin/enable.sh
+  bin/disable.sh: bin/disable.sh
+
+properties:
+  iptables:
+    description: "Map of rules per chain per table to apply in iptables"
+    default: {}
+    example:
+      nat:            # one of: nat, filter, raw, mangle, security
+        POSTROUTING:  # a valid chain
+        - -s 10.244.0.0/24 -j MASQUERADE

--- a/jobs/iptables/templates/bin/ctl
+++ b/jobs/iptables/templates/bin/ctl
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e -u
+
+mkdir -p /var/vcap/sys/run/iptables
+
+case $1 in
+
+  start)
+      /var/vcap/jobs/iptables/bin/enable.sh
+      touch /var/vcap/sys/run/iptables/iptables.check
+      ;;
+
+  stop)
+      /var/vcap/jobs/iptables/bin/disable.sh
+      rm /var/vcap/sys/run/iptables/iptables.check
+      ;;
+  *)
+
+esac
+
+exit 0

--- a/jobs/iptables/templates/bin/disable.sh
+++ b/jobs/iptables/templates/bin/disable.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+<% p("iptables").each do |table, chains|
+	chains.each do |chain, rules| %>
+
+iptables -t "<%= table %>" -F "pfbr-custom-<%= chain %>"
+
+	<% end %>
+<% end %>

--- a/jobs/iptables/templates/bin/enable.sh
+++ b/jobs/iptables/templates/bin/enable.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+function setup_chain {
+	table=$1
+	orig_chain=$2
+	target_chain=$3
+
+	if ! iptables -t "${table}" -L "${target_chain}" >/dev/null 2>&1; then
+		iptables -t "${table}" -N "${target_chain}"
+	fi
+
+	if ! iptables -t "${table}" -C "${orig_chain}" -j "${target_chain}" 2>/dev/null; then
+		iptables -t "${table}" -A "${orig_chain}" -j "${target_chain}"
+	fi
+}
+
+<% p("iptables").each do |table, chains|
+	chains.each do |chain, rules| %>
+
+setup_chain "<%= table %>" "<%= chain %>" "pfbr-custom-<%= chain %>"
+
+<% rules.each do |rule| %>
+	iptables -t "${table}" -A "pfbr-custom-<%= chain %>"  <%= rule %>
+<% end %>
+
+	<% end %>
+<% end %>


### PR DESCRIPTION
The iptables job was previously part of the networking-release which has been archived three years ago. This PR copies the job and adds it to this release as we still rely on it to deploy some rules to redirect traffic.

See: https://github.com/cloudfoundry-attic/networking-release